### PR TITLE
Fix missing fr-FR device status variables

### DIFF
--- a/skill_homeassistant/locale/fr-fr/dialog/device.status.dialog
+++ b/skill_homeassistant/locale/fr-fr/dialog/device.status.dialog
@@ -1,3 +1,3 @@
-L'appareil {type} {device} est actuellement {state}.
-Home Assistant indique que {type} {device} est {state}.
-Pour l'appareil {type} {device}, l'état actuel est {state}.
+L'appareil {device}, de type {type}, est actuellement {state}.
+Home Assistant indique que l'appareil {device}, de type {type}, est {state}.
+Pour {device}, qui est de type {type}, l'état actuel est {state}.

--- a/skill_homeassistant/locale/fr-fr/dialog/device.status.dialog
+++ b/skill_homeassistant/locale/fr-fr/dialog/device.status.dialog
@@ -1,3 +1,3 @@
-L'état de {device} est {state}.
-Home Assistant indique que {device} est {state}.
-Pour {device}, l'état actuel est {state}.
+L'appareil {type} {device} est actuellement {state}.
+Home Assistant indique que {type} {device} est {state}.
+Pour l'appareil {type} {device}, l'état actuel est {state}.


### PR DESCRIPTION
## Summary
- restore the missing `{type}` placeholder in fr-FR `device.status.dialog`
- keep the French phrasing natural for spoken Home Assistant responses
- fix issue #44 without changing runtime code

## Validation
- placeholder parity check against `en-us` dialogs
- `python -m compileall skill_homeassistant`
- `git diff --check`

Closes #44