### PR TITLE
feat: add Home Assistant script domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This unified skill replaces the legacy `neon-homeassistant-skill` and `ovos-PHAL
 - Control switches and outlets
 - Monitor sensors
 - Control covers (open/close, position)
+- Activate scenes and run scripts (e.g. "turn on movie night")
 - Silent mode for specific devices
 - Support for Home Assistant Assist API
 

--- a/skill_homeassistant/ha_client/constants.py
+++ b/skill_homeassistant/ha_client/constants.py
@@ -11,6 +11,7 @@ from skill_homeassistant.ha_client.logic.device import (
     HomeAssistantLight,
     HomeAssistantMediaPlayer,
     HomeAssistantScene,
+    HomeAssistantScript,
     HomeAssistantSensor,
     HomeAssistantSwitch,
     HomeAssistantVacuum,
@@ -26,5 +27,6 @@ SUPPORTED_DEVICES = {
     "climate": HomeAssistantClimate,
     "camera": HomeAssistantCamera,
     "scene": HomeAssistantScene,
+    "script": HomeAssistantScript,
     "automation": HomeAssistantAutomation,
 }

--- a/skill_homeassistant/ha_client/logic/device.py
+++ b/skill_homeassistant/ha_client/logic/device.py
@@ -733,3 +733,16 @@ class HomeAssistantAutomation(HomeAssistantDevice):
     def turn_off(self):
         LOG.warning("Request to turn off an automation. This is not supported, as it will disable it instead.")
         return
+
+
+class HomeAssistantScript(HomeAssistantDevice):
+    """Home Assistant Script"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def turn_off(self):
+        # script.turn_off would abort a running script. We deliberately decline via voice to avoid
+        # surprising behavior; scripts are activated ("run"), mirroring how scenes are handled.
+        LOG.warning("Request to turn off a script. This is not supported - scripts can only be run.")
+        return

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -107,6 +107,15 @@ class TestHomeAssistantClient(unittest.TestCase):
                 {"friendly_name": "Test Scene"},
                 "Living Room",
             ),
+            cls.plugin.device_types["script"](
+                FakeConnector(),
+                "test_script",
+                "mdi:script-text",
+                "test_script",
+                "off",
+                {"friendly_name": "Test Script"},
+                "Living Room",
+            ),
             cls.plugin.device_types["automation"](
                 FakeConnector(),
                 "test_automation",

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -12,6 +12,7 @@ from skill_homeassistant.ha_client.logic.device import (
     HomeAssistantClimate,
     HomeAssistantVacuum,
     HomeAssistantScene,
+    HomeAssistantScript,
     HomeAssistantAutomation,
 )
 
@@ -642,6 +643,43 @@ class TestHomeAssistantAutomation(unittest.TestCase):
             self.assertIsNone(result)
             # Verify connector.turn_off was NOT called (automation overrides to do nothing)
             connector.turn_off.assert_not_called()
+
+
+class TestHomeAssistantScript(unittest.TestCase):
+    """Tests for HomeAssistantScript behavior."""
+
+    def _make_script(self, connector):
+        return HomeAssistantScript(
+            connector=connector,
+            device_id="script.movie_night",
+            device_icon="mdi:script-text",
+            device_name="Movie Night",
+            device_state="off",
+            device_attributes={},
+        )
+
+    def test_turn_off_logs_warning_and_returns_none(self):
+        """Script turn_off is a no-op warning (scripts are run, not turned off via voice)."""
+        connector = FakeConnector()
+        connector.turn_off = Mock()  # Track if it gets called
+        script = self._make_script(connector)
+
+        with patch("skill_homeassistant.ha_client.logic.device.LOG") as mock_log:
+            result = script.turn_off()
+            mock_log.warning.assert_called()
+            self.assertIsNone(result)
+            # Verify connector.turn_off was NOT called (script overrides to do nothing)
+            connector.turn_off.assert_not_called()
+
+    def test_turn_on_runs_the_script(self):
+        """Script turn_on activates the script via the connector (the 'run' path)."""
+        connector = FakeConnector()
+        connector.turn_on = Mock()
+        script = self._make_script(connector)
+
+        script.turn_on()
+        # Scripts run via the standard turn_on service call (script.turn_on)
+        connector.turn_on.assert_called_once_with("script.movie_night", "script")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds support for the Home Assistant `script` domain — scripts can now be activated by voice via the existing "turn on {entity}" path, mirroring how scenes work.
- Registers `script` → `HomeAssistantScript` in `SUPPORTED_DEVICES`; the device class inherits the standard `turn_on` (fires `script.turn_on`) and overrides `turn_off` to a no-op warning so a voice "turn off" can't abort a running script.
- No new intents added — deliberately avoids a dedicated "run" verb, which collides with default-skill intents. Works across all locales for free since it rides the generic turn-on intent.

## Test plan
- `poetry run pytest test/ --ignore=test/e2e` → 166 passed
- New `TestHomeAssistantScript` covers both the no-op `turn_off` and the working `turn_on` (run) path
- Added a `script` entity to the client fixture, satisfying the all-supported-domains-covered guard test

🤖 Generated with [Claude Code](https://claude.com/claude-code)