### PR TITLE
feat: add da-dk and sv-se translations

### DIFF
--- a/skill_homeassistant/locale/da-dk/dialog/acknowledge.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/acknowledge.dialog
@@ -1,0 +1,5 @@
+Okay.
+Med det samme!
+Det skal jeg nok.
+Så gerne.
+Det bliver gjort.

--- a/skill_homeassistant/locale/da-dk/dialog/assist.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/assist.dialog
@@ -1,0 +1,3 @@
+Jeg fortalte det til Home Assistant.
+Jeg lod Home Assistant vide det.
+Jeg bliver lidt jaloux når du taler med andre stemmeassistenter, men jeg gjorde det alligevel.

--- a/skill_homeassistant/locale/da-dk/dialog/assist.error.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/assist.error.dialog
@@ -1,0 +1,1 @@
+Home Assistant returnerede en fejl. Tjek venligst skillets logfiler for mere information.

--- a/skill_homeassistant/locale/da-dk/dialog/assist.not.understood.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/assist.not.understood.dialog
@@ -1,0 +1,2 @@
+Undskyld, jeg fangede ikke hvad jeg skulle fortælle Home Assistant.
+Kan du venligst sige igen hvilken besked jeg skal sende til Home Assistant?

--- a/skill_homeassistant/locale/da-dk/dialog/device.not.found.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/device.not.found.dialog
@@ -1,0 +1,3 @@
+Det efterspurgte {device} blev ikke fundet. Prøv venligst igen.
+Kunne ikke finde {device} i Home Assistant.
+Beklager, Home Assistant fortalte mig ikke noget om {device}.

--- a/skill_homeassistant/locale/da-dk/dialog/device.status.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/device.status.dialog
@@ -1,0 +1,3 @@
+{type} {device} viser tilstanden {state}
+{type} kaldet {device} er i øjeblikket {state}
+Home Assistant fortæller mig at {type} {device} er {state}

--- a/skill_homeassistant/locale/da-dk/dialog/device.turned.off.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/device.turned.off.dialog
@@ -1,0 +1,3 @@
+Okay, slukkede {device}.
+{device} er nu slukket.
+Jeg slukkede {device}!

--- a/skill_homeassistant/locale/da-dk/dialog/device.turned.on.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/device.turned.on.dialog
@@ -1,0 +1,3 @@
+Okay, tændte {device}.
+{device} er nu tændt.
+Jeg tændte {device}!

--- a/skill_homeassistant/locale/da-dk/dialog/disable.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/disable.dialog
@@ -1,0 +1,2 @@
+Deaktiverer Home Assistant-intentioner. Sig til hvis du skifter mening.
+Jeg svarer ikke længere på Home Assistant-intentioner.

--- a/skill_homeassistant/locale/da-dk/dialog/enable.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/enable.dialog
@@ -1,0 +1,2 @@
+Aktiverer Home Assistant-intentioner!
+Jeg begynder at svare på Home Assistant-intentioner.

--- a/skill_homeassistant/locale/da-dk/dialog/lights.current.brightness.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/lights.current.brightness.dialog
@@ -1,0 +1,2 @@
+den nuværende lysstyrke for {{device}} er {{brightness}} procent
+{{device}} er på {{brightness}} procent lysstyrke

--- a/skill_homeassistant/locale/da-dk/dialog/lights.current.color.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/lights.current.color.dialog
@@ -1,0 +1,2 @@
+den nuværende farve for {{device}} er {{color}}
+{{device}} har nu en dejlig nuance af {{color}}

--- a/skill_homeassistant/locale/da-dk/dialog/lights.status.not.available.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/lights.status.not.available.dialog
@@ -1,0 +1,1 @@
+Statussen for {device} er ikke tilgængelig. Sørg for at den er tændt og prøv igen.

--- a/skill_homeassistant/locale/da-dk/dialog/no.parsed.color.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/no.parsed.color.dialog
@@ -1,0 +1,2 @@
+Hvilken farve skal jeg bruge?
+Jeg fangede ikke hvilken farve du vil have.

--- a/skill_homeassistant/locale/da-dk/dialog/no.parsed.device.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/no.parsed.device.dialog
@@ -1,0 +1,2 @@
+Hvilken enhed var det? Jeg forstod det ikke helt.
+Jeg er ikke sikker på hvilken enhed du mener.

--- a/skill_homeassistant/locale/da-dk/dialog/rebuild.complete.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/rebuild.complete.dialog
@@ -1,0 +1,3 @@
+Enhedslisten blev opdateret. Fandt {count} enheder.
+Genopbygning fuldført. {count} enheder er nu tilgængelige.
+Færdig! Jeg fandt {count} enheder fra Home Assistant.

--- a/skill_homeassistant/locale/da-dk/dialog/vacuum.action.not.found.dialog
+++ b/skill_homeassistant/locale/da-dk/dialog/vacuum.action.not.found.dialog
@@ -1,0 +1,2 @@
+Beklager, jeg ved kun hvordan man starter, stopper eller sætter en støvsuger på pause, ikke {action}
+Du bad mig om at {action} støvsugeren, men jeg kan kun starte, stoppe eller sætte den på pause.

--- a/skill_homeassistant/locale/da-dk/intents/assist.intent
+++ b/skill_homeassistant/locale/da-dk/intents/assist.intent
@@ -1,0 +1,1 @@
+sig til home assistant (|at){command}

--- a/skill_homeassistant/locale/da-dk/intents/disable.intent
+++ b/skill_homeassistant/locale/da-dk/intents/disable.intent
@@ -1,0 +1,2 @@
+Deaktiver Home Assistant
+Jeg bruger ikke Home Assistant

--- a/skill_homeassistant/locale/da-dk/intents/enable.intent
+++ b/skill_homeassistant/locale/da-dk/intents/enable.intent
@@ -1,0 +1,2 @@
+Aktiver Home Assistant
+Jeg vil gerne bruge Home Assistant

--- a/skill_homeassistant/locale/da-dk/intents/get.all.devices.intent
+++ b/skill_homeassistant/locale/da-dk/intents/get.all.devices.intent
@@ -1,0 +1,1 @@
+genopbyg enhedsliste

--- a/skill_homeassistant/locale/da-dk/intents/lights.decrease.brightness.intent
+++ b/skill_homeassistant/locale/da-dk/intents/lights.decrease.brightness.intent
@@ -1,0 +1,3 @@
+sænk (|lysstyrken) for (|den|min) {entity}
+gør (|den|min) {entity} svagere
+dæmp (|ned) (|lysstyrken) (|for) (|den|min) {entity}

--- a/skill_homeassistant/locale/da-dk/intents/lights.get.brightness.intent
+++ b/skill_homeassistant/locale/da-dk/intents/lights.get.brightness.intent
@@ -1,0 +1,2 @@
+(hent|forespørg) (|den nuværende) lysstyrke for (|den|min) {entity}
+hvad er (|den nuværende) lysstyrke for (|den|min) {entity}

--- a/skill_homeassistant/locale/da-dk/intents/lights.get.color.intent
+++ b/skill_homeassistant/locale/da-dk/intents/lights.get.color.intent
@@ -1,0 +1,2 @@
+(hent|forespørg) (|den nuværende) farve på (|den|min) {entity}
+hvad er (|den nuværende) farve på (|den|min) {entity}

--- a/skill_homeassistant/locale/da-dk/intents/lights.increase.brightness.intent
+++ b/skill_homeassistant/locale/da-dk/intents/lights.increase.brightness.intent
@@ -1,0 +1,3 @@
+øg (|lysstyrken) for (|den|min) {entity}
+gør (|den|min) {entity} lysere
+skru (|op for) (|lysstyrken) (|for) (|den|min) {entity}

--- a/skill_homeassistant/locale/da-dk/intents/lights.set.brightness.intent
+++ b/skill_homeassistant/locale/da-dk/intents/lights.set.brightness.intent
@@ -1,0 +1,2 @@
+(sæt|ændr) (|lysstyrken) for (|den|min) {entity} til {brightness} (|procent)
+sæt (|den|min) {entity}s lysstyrke til {brightness} (|procent)

--- a/skill_homeassistant/locale/da-dk/intents/lights.set.color.intent
+++ b/skill_homeassistant/locale/da-dk/intents/lights.set.color.intent
@@ -1,0 +1,2 @@
+(juster|ændr|gør) (|den|min) {entity}s farve (til |){color}
+(juster|ændr|gør) (|den|min) lys {entity} (til |){color}

--- a/skill_homeassistant/locale/da-dk/intents/sensor.intent
+++ b/skill_homeassistant/locale/da-dk/intents/sensor.intent
@@ -1,0 +1,3 @@
+(hvad er|giv mig|fortæl mig|hent) (|temperaturen|farvetonen|værdien|tilstanden|status|aflæsningen) for (|den|min) {entity} (venligst|).
+er (|den|min) {entity} (tændt|slukket|høj|lav|kold|varm|meget varm|forbundet|afbrudt|åben|lukket|mørk|i bevægelse|optaget|tilsluttet|sikret|usikret|opladning|tilgængelig)
+har (|den|min) {entity} registreret (|en) (fugt|energi|problem|vibration|gas|lyd)

--- a/skill_homeassistant/locale/da-dk/intents/stop.intent
+++ b/skill_homeassistant/locale/da-dk/intents/stop.intent
@@ -1,0 +1,4 @@
+stop (|den|min) {entity}
+Kan du stoppe (|den|min) {entity} venligst?
+Jeg vil gerne stoppe (|den|min) {entity}
+Jeg vil gerne have (|den|min) {entity} stoppet

--- a/skill_homeassistant/locale/da-dk/intents/turn.off.intent
+++ b/skill_homeassistant/locale/da-dk/intents/turn.off.intent
@@ -1,0 +1,5 @@
+sluk (|den|min) {entity}
+sluk for (|den|min) {entity}
+(Kan|Vil) du slukke (|den|min) {entity} venligst?
+Jeg vil gerne slukke (|den|min) {entity}
+Jeg vil gerne have (|den|min) {entity} slukket

--- a/skill_homeassistant/locale/da-dk/intents/turn.on.intent
+++ b/skill_homeassistant/locale/da-dk/intents/turn.on.intent
@@ -1,0 +1,5 @@
+tænd (|den|min) {entity}
+tænd for (|den|min) {entity}
+(Kan|Vil) du tænde (|den|min) {entity} venligst?
+Jeg vil gerne tænde (|den|min) {entity}
+Jeg vil gerne have (|den|min) {entity} tændt

--- a/skill_homeassistant/locale/da-dk/skill.json
+++ b/skill_homeassistant/locale/da-dk/skill.json
@@ -1,0 +1,30 @@
+{
+    "skill_id": "skill_homeassistant.oscillatelabsllc",
+    "source": "https://github.com/oscillatelabsllc/skill-homeassistant",
+    "package_name": "skill-homeassistant",
+    "pip_spec": "skill-homeassistant",
+    "license": "Apache-2.0",
+    "author": [
+        "Mike Gray <mike@oscillatelabs.net>"
+    ],
+    "icon": "https://www.home-assistant.io/images/home-assistant-logo.svg",
+    "images": [],
+    "name": "skill-homeassistant",
+    "description": "skill-homeassistant",
+    "examples": [
+        "Hvad er status på stuelampen?",
+        "Tænd køkkenlyset",
+        "Skift sengelampen til blå"
+    ],
+    "tags": [
+        "ovos",
+        "neon",
+        "home",
+        "assistant",
+        "voice",
+        "interface",
+        "skill",
+        "plugin"
+    ],
+    "version": "1.3.0"
+}

--- a/skill_homeassistant/locale/sv-se/dialog/acknowledge.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/acknowledge.dialog
@@ -1,0 +1,5 @@
+Okej.
+Direkt!
+Absolut.
+Visst.
+Det kommer att göras.

--- a/skill_homeassistant/locale/sv-se/dialog/assist.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/assist.dialog
@@ -1,0 +1,3 @@
+Jag berättade det för Home Assistant.
+Jag lät Home Assistant veta det.
+Jag blir lite avundsjuk när du pratar med andra röstassistenter, men jag gjorde det ändå.

--- a/skill_homeassistant/locale/sv-se/dialog/assist.error.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/assist.error.dialog
@@ -1,0 +1,1 @@
+Home Assistant returnerade ett fel. Kontrollera skillets loggar för mer information.

--- a/skill_homeassistant/locale/sv-se/dialog/assist.not.understood.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/assist.not.understood.dialog
@@ -1,0 +1,2 @@
+Förlåt, jag uppfattade inte vad jag skulle säga till Home Assistant.
+Kan du vänligen säga igen vilket meddelande jag ska skicka till Home Assistant?

--- a/skill_homeassistant/locale/sv-se/dialog/device.not.found.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/device.not.found.dialog
@@ -1,0 +1,3 @@
+Den efterfrågade {device} hittades inte. Försök igen.
+Kunde inte hitta {device} i Home Assistant.
+Tyvärr, Home Assistant berättade inget om {device} för mig.

--- a/skill_homeassistant/locale/sv-se/dialog/device.status.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/device.status.dialog
@@ -1,0 +1,3 @@
+{type} {device} visar tillståndet {state}
+{type} som kallas {device} är just nu {state}
+Home Assistant säger att {type} {device} är {state}

--- a/skill_homeassistant/locale/sv-se/dialog/device.turned.off.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/device.turned.off.dialog
@@ -1,0 +1,3 @@
+Okej, stängde av {device}.
+{device} är nu avstängd.
+Jag stängde av {device}!

--- a/skill_homeassistant/locale/sv-se/dialog/device.turned.on.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/device.turned.on.dialog
@@ -1,0 +1,3 @@
+Okej, slog på {device}.
+{device} är nu på.
+Jag slog på {device}!

--- a/skill_homeassistant/locale/sv-se/dialog/disable.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/disable.dialog
@@ -1,0 +1,2 @@
+Inaktiverar Home Assistant-avsikter. Säg till om du ändrar dig.
+Jag svarar inte längre på Home Assistant-avsikter.

--- a/skill_homeassistant/locale/sv-se/dialog/enable.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/enable.dialog
@@ -1,0 +1,2 @@
+Aktiverar Home Assistant-avsikter!
+Jag börjar svara på Home Assistant-avsikter.

--- a/skill_homeassistant/locale/sv-se/dialog/lights.current.brightness.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/lights.current.brightness.dialog
@@ -1,0 +1,2 @@
+den nuvarande ljusstyrkan för {{device}} är {{brightness}} procent
+{{device}} är på {{brightness}} procent ljusstyrka

--- a/skill_homeassistant/locale/sv-se/dialog/lights.current.color.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/lights.current.color.dialog
@@ -1,0 +1,2 @@
+den nuvarande färgen för {{device}} är {{color}}
+{{device}} har nu en fin nyans av {{color}}

--- a/skill_homeassistant/locale/sv-se/dialog/lights.status.not.available.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/lights.status.not.available.dialog
@@ -1,0 +1,1 @@
+Statusen för {device} är inte tillgänglig. Se till att den är påslagen och försök igen.

--- a/skill_homeassistant/locale/sv-se/dialog/no.parsed.color.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/no.parsed.color.dialog
@@ -1,0 +1,2 @@
+Vilken färg ska jag använda?
+Jag uppfattade inte vilken färg du vill ha.

--- a/skill_homeassistant/locale/sv-se/dialog/no.parsed.device.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/no.parsed.device.dialog
@@ -1,0 +1,2 @@
+Vilken enhet var det? Jag förstod inte riktigt.
+Jag är inte säker på vilken enhet du menar.

--- a/skill_homeassistant/locale/sv-se/dialog/rebuild.complete.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/rebuild.complete.dialog
@@ -1,0 +1,3 @@
+Enhetslistan uppdaterades. Hittade {count} enheter.
+Ombyggnad klar. {count} enheter är nu tillgängliga.
+Klart! Jag hittade {count} enheter från Home Assistant.

--- a/skill_homeassistant/locale/sv-se/dialog/vacuum.action.not.found.dialog
+++ b/skill_homeassistant/locale/sv-se/dialog/vacuum.action.not.found.dialog
@@ -1,0 +1,2 @@
+Tyvärr, jag vet bara hur man startar, stoppar eller pausar en dammsugare, inte {action}
+Du bad mig {action} dammsugaren, men jag kan bara starta, stoppa eller pausa den.

--- a/skill_homeassistant/locale/sv-se/intents/assist.intent
+++ b/skill_homeassistant/locale/sv-se/intents/assist.intent
@@ -1,0 +1,1 @@
+säg till home assistant (|att){command}

--- a/skill_homeassistant/locale/sv-se/intents/disable.intent
+++ b/skill_homeassistant/locale/sv-se/intents/disable.intent
@@ -1,0 +1,2 @@
+Inaktivera Home Assistant
+Jag använder inte Home Assistant

--- a/skill_homeassistant/locale/sv-se/intents/enable.intent
+++ b/skill_homeassistant/locale/sv-se/intents/enable.intent
@@ -1,0 +1,2 @@
+Aktivera Home Assistant
+Jag vill använda Home Assistant

--- a/skill_homeassistant/locale/sv-se/intents/get.all.devices.intent
+++ b/skill_homeassistant/locale/sv-se/intents/get.all.devices.intent
@@ -1,0 +1,1 @@
+bygg om enhetslista

--- a/skill_homeassistant/locale/sv-se/intents/lights.decrease.brightness.intent
+++ b/skill_homeassistant/locale/sv-se/intents/lights.decrease.brightness.intent
@@ -1,0 +1,3 @@
+sänk (|ljusstyrkan) för (|den|min) {entity}
+gör (|den|min) {entity} svagare
+dämpa (|ner) (|ljusstyrkan) (|för) (|den|min) {entity}

--- a/skill_homeassistant/locale/sv-se/intents/lights.get.brightness.intent
+++ b/skill_homeassistant/locale/sv-se/intents/lights.get.brightness.intent
@@ -1,0 +1,2 @@
+(hämta|fråga efter) (|den nuvarande) ljusstyrkan för (|den|min) {entity}
+vad är (|den nuvarande) ljusstyrkan för (|den|min) {entity}

--- a/skill_homeassistant/locale/sv-se/intents/lights.get.color.intent
+++ b/skill_homeassistant/locale/sv-se/intents/lights.get.color.intent
@@ -1,0 +1,2 @@
+(hämta|fråga efter) (|den nuvarande) färgen på (|den|min) {entity}
+vad är (|den nuvarande) färgen på (|den|min) {entity}

--- a/skill_homeassistant/locale/sv-se/intents/lights.increase.brightness.intent
+++ b/skill_homeassistant/locale/sv-se/intents/lights.increase.brightness.intent
@@ -1,0 +1,3 @@
+öka (|ljusstyrkan) för (|den|min) {entity}
+gör (|den|min) {entity} ljusare
+skruva (|upp) (|ljusstyrkan) (|för) (|den|min) {entity}

--- a/skill_homeassistant/locale/sv-se/intents/lights.set.brightness.intent
+++ b/skill_homeassistant/locale/sv-se/intents/lights.set.brightness.intent
@@ -1,0 +1,2 @@
+(ställ in|ändra) (|ljusstyrkan) för (|den|min) {entity} till {brightness} (|procent)
+ställ in (|den|min) {entity}s ljusstyrka till {brightness} (|procent)

--- a/skill_homeassistant/locale/sv-se/intents/lights.set.color.intent
+++ b/skill_homeassistant/locale/sv-se/intents/lights.set.color.intent
@@ -1,0 +1,2 @@
+(justera|ändra|gör) (|den|min) {entity}s färg (till |){color}
+(justera|ändra|gör) (|den|min) lampa {entity} (till |){color}

--- a/skill_homeassistant/locale/sv-se/intents/sensor.intent
+++ b/skill_homeassistant/locale/sv-se/intents/sensor.intent
@@ -1,0 +1,3 @@
+(vad är|ge mig|berätta för mig|hämta) (|temperaturen|nyansen|värdet|tillståndet|status|avläsningen) för (|den|min) {entity} (snälla|).
+är (|den|min) {entity} (på|av|hög|låg|kall|varm|het|ansluten|frånkopplad|öppen|stängd|mörk|i rörelse|upptagen|inkopplad|säkrad|osäkrad|laddar|tillgänglig)
+har (|den|min) {entity} upptäckt (|en) (fukt|energi|problem|vibration|gas|ljud)

--- a/skill_homeassistant/locale/sv-se/intents/stop.intent
+++ b/skill_homeassistant/locale/sv-se/intents/stop.intent
@@ -1,0 +1,4 @@
+stoppa (|den|min) {entity}
+Kan du stoppa (|den|min) {entity} snälla?
+Jag skulle vilja stoppa (|den|min) {entity}
+Jag skulle vilja ha (|den|min) {entity} stoppad

--- a/skill_homeassistant/locale/sv-se/intents/turn.off.intent
+++ b/skill_homeassistant/locale/sv-se/intents/turn.off.intent
@@ -1,0 +1,5 @@
+stäng av (|den|min) {entity}
+stäng (|den|min) {entity} av
+(Kan|Skulle) du stänga av (|den|min) {entity} snälla?
+Jag skulle vilja stänga av (|den|min) {entity}
+Jag skulle vilja ha (|den|min) {entity} avstängd

--- a/skill_homeassistant/locale/sv-se/intents/turn.on.intent
+++ b/skill_homeassistant/locale/sv-se/intents/turn.on.intent
@@ -1,0 +1,5 @@
+slå på (|den|min) {entity}
+slå (|den|min) {entity} på
+(Kan|Skulle) du slå på (|den|min) {entity} snälla?
+Jag skulle vilja slå på (|den|min) {entity}
+Jag skulle vilja ha (|den|min) {entity} påslagen

--- a/skill_homeassistant/locale/sv-se/skill.json
+++ b/skill_homeassistant/locale/sv-se/skill.json
@@ -1,0 +1,30 @@
+{
+    "skill_id": "skill_homeassistant.oscillatelabsllc",
+    "source": "https://github.com/oscillatelabsllc/skill-homeassistant",
+    "package_name": "skill-homeassistant",
+    "pip_spec": "skill-homeassistant",
+    "license": "Apache-2.0",
+    "author": [
+        "Mike Gray <mike@oscillatelabs.net>"
+    ],
+    "icon": "https://www.home-assistant.io/images/home-assistant-logo.svg",
+    "images": [],
+    "name": "skill-homeassistant",
+    "description": "skill-homeassistant",
+    "examples": [
+        "Vad är statusen på vardagsrumslampan?",
+        "Slå på kökslampan",
+        "Ändra sänglampan till blå"
+    ],
+    "tags": [
+        "ovos",
+        "neon",
+        "home",
+        "assistant",
+        "voice",
+        "interface",
+        "skill",
+        "plugin"
+    ],
+    "version": "1.3.0"
+}


### PR DESCRIPTION
Neither Danish nor Swedish had any translation for this skill. Added both, covering all 17 dialog files, 14 intent files, and skill.json (32 files per language, 64 total).

Kept all `{variable}`/`{{double_brace}}` placeholders unchanged as required, and matched the Padatious alternation syntax used by the existing en-us/es-es/fr-fr/pl-pl locales.

Ran `ovos_localize.cli.validate` against both - no errors specific to these translations. The one ERROR that does show up (`assist.dialog` missing `{command}`) is a pre-existing issue that affects every locale including en-us itself, unrelated to this change.

**Confidence note:** Danish is high confidence (native-level review). Swedish is good but not native-level - would appreciate a native speaker double-checking before merge, flagging that explicitly.